### PR TITLE
Add multi-page UI with emulator section

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,12 +34,20 @@ async def shutdown() -> None:
 async def index(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
+@app.get("/emulator", response_class=HTMLResponse)
+async def emulator(request: Request):
+    return templates.TemplateResponse("emulator.html", {"request": request})
+
 @app.get("/notes", response_class=HTMLResponse)
+async def notes_page(request: Request):
+    return templates.TemplateResponse("notes.html", {"request": request})
+
+@app.get("/notes/items", response_class=HTMLResponse)
 async def notes_list(request: Request, db: Session = Depends(get_session)):
     notes = db.query(models.Note).order_by(models.Note.id.desc()).all()
     return templates.TemplateResponse("partials/notes_items.html", {"request": request, "notes": notes})
 
-@app.post("/notes", response_class=HTMLResponse)
+@app.post("/notes/items", response_class=HTMLResponse)
 async def notes_create(request: Request, content: str = Form(...), db: Session = Depends(get_session)):
     note = models.Note(content=content)
     db.add(note)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,1 +1,22 @@
-body { font-family: sans-serif; }
+body {
+  font-family: sans-serif;
+  margin: 0;
+  background: #f0f2f5;
+}
+nav {
+  background: #333;
+  padding: 1rem;
+}
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+main {
+  padding: 2rem;
+}
+.emulator-container {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+}

--- a/app/views/base.html
+++ b/app/views/base.html
@@ -4,19 +4,16 @@
   <meta charset="UTF-8">
   <title>{{ title or 'my-site' }}</title>
   <script src="https://unpkg.com/htmx.org@1.9.2"></script>
-  <style>html,body{margin:0;padding:0}</style>
+  <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <div style="width:100%;height:100%;max-width:100%"><div id="game"></div></div>
-  <script>
-    EJS_player = "#game";
-    EJS_core = "gba";
-    EJS_gameName = "gameitup";
-    EJS_color = "#0064ff";
-    EJS_startOnLoaded = true;
-    EJS_pathtodata = "/static/emulatorjs/data/";     // must end with trailing slash
-    EJS_gameUrl = "/static/emulatorjs/roms/therom.gba";    // serve the ROM via /static
-  </script>
-  <script src="/static/emulatorjs/data/loader.js"></script>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/notes">Notes</a>
+    <a href="/emulator">Emulator</a>
+  </nav>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
 </body>
 </html>

--- a/app/views/emulator.html
+++ b/app/views/emulator.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="emulator-container"><div id="game"></div></div>
+<script>
+  EJS_player = "#game";
+  EJS_core = "gba";
+  EJS_gameName = "gameitup";
+  EJS_color = "#0064ff";
+  EJS_startOnLoaded = true;
+  EJS_pathtodata = "/static/emulatorjs/data/";
+  EJS_gameUrl = "/static/emulatorjs/roms/therom.gba";
+</script>
+<script src="/static/emulatorjs/data/loader.js"></script>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Hello from Raspberry Pi</h1>
-<a href="/notes">Notes</a>
+<h1>Welcome to my-site</h1>
+<p>Use the navigation above to explore notes or launch the emulator.</p>
 {% endblock %}

--- a/app/views/notes.html
+++ b/app/views/notes.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Notes</h1>
-<div id="notes-list" hx-get="/notes" hx-trigger="load"></div>
-<form hx-post="/notes" hx-target="#notes-list" hx-swap="afterbegin">
+<div id="notes-list" hx-get="/notes/items" hx-trigger="load"></div>
+<form hx-post="/notes/items" hx-target="#notes-list" hx-swap="afterbegin">
     <input name="content" placeholder="note" />
     <button type="submit">Add</button>
 </form>


### PR DESCRIPTION
## Summary
- Introduce a base layout with navigation and CSS styling
- Add dedicated emulator page and notes page
- Wire up FastAPI routes for home, notes, and emulator

## Testing
- `PYTHONPATH=. make test`

------
https://chatgpt.com/codex/tasks/task_e_6898e2540e20832484820f884c1d81bb